### PR TITLE
パララックスデザインがスマホだと崩れる。

### DIFF
--- a/components/Parallax.vue
+++ b/components/Parallax.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="parallax_box">
+    <div class='parallax parallax_bg_img'></div>
+  </div>
+</template>
+
+<style>
+  .parallax_box {
+    width: 100%;
+    height: 100vh;
+    position: relative;
+  }
+
+  .parallax {
+    width: 100%;
+    min-height: 100vh;
+    background-repeat: no-repeat;
+    background-size: cover;
+    display: block;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: -1;
+  }
+
+  .parallax::before {
+    content: "";
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background-repeat: no-repeat;
+    background-size: cover;
+    z-index: -1;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  .parallax_bg_img {
+    background-image: url(~@/assets/img/riverbank.png);
+  }
+  .parallax_bg_img::before {
+    background-image: url(~@/assets/img/riverbank.png);
+  }
+</style>

--- a/components/Skill.vue
+++ b/components/Skill.vue
@@ -15,43 +15,14 @@
         <img src='@/assets/img/git-hub.png' class='skill_icon' data-aos='fade-up' />
       </div>
     </div>
-    <div class='parallax parallax_bg_img'></div>
   </div>
 </template>
 
 <style>
-  .parallax {
-    width: 100%;
-    min-height: 300px;
-    background-position: center top;
-    background-repeat: no-repeat;
-    background-attachment: fixed;
-    background-size: cover;    
-  }
-
-  .parallax::before {
-    display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 300px;
-    -webkit-transform: translate3d(0, 0, -1px);
-    transform: translate3d(0, 0, -1px);
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    z-index: -1;
-  }
-  .parallax_bg_img {
-    background-image: url(~@/assets/img/riverbank.png);
-  }
-  .parallax_bg_img::before {
-    background-image: url(~@/assets/img/riverbank.png);
-  }
-
   .skill {
+    background-color: rgb(255,255,255);
     text-align: center;
+    z-index: 2;
   }
 
   .skill_container {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,6 +4,7 @@
     <Introduction />
     <Overview />
     <Skill />
+    <Parallax />
     <Masterpiece />
 
     <div class='contact_area' id='contact'>
@@ -52,6 +53,7 @@ import Header       from '~/components/Header.vue'
 import Introduction from '~/components/Introduction.vue'
 import Overview     from '~/components/Overview.vue'
 import Skill        from '~/components/Skill.vue'
+import Parallax     from '~/components/Parallax.vue'
 import Masterpiece  from '~/components/Masterpiece.vue'
 import axios from 'axios'
 
@@ -61,6 +63,7 @@ export default {
     Introduction,
     Overview,
     Skill,
+    Parallax,
     Masterpiece,
   },
   data() {
@@ -128,6 +131,7 @@ export default {
   .contact_area {
     padding: 50px;
     text-align: center;
+    background-color: rgb(255,255,255);
   }
   .contact_title {
     padding: 10px;


### PR DESCRIPTION
パララックスデザインを実装したが、スマホ(iOS)ではデザインが崩れてしまうのを修正する。

background-attachment：fixedとbackground-size: coverを同時に使用するのはタブーだったので、position: fixedで指定するように変更した。